### PR TITLE
Increase contentTypeParser to 100%

### DIFF
--- a/test/internals/contentTypeParser.test.js
+++ b/test/internals/contentTypeParser.test.js
@@ -8,13 +8,19 @@ const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 
 test('rawBody function', t => {
-  t.plan(1)
+  t.plan(2)
   const body = Buffer.from('你好 世界')
   const parser = {
     asString: true,
     asBuffer: false,
-    fn (req, bodyInString) {
+    fn (req, bodyInString, done) {
       t.equal(bodyInString, body.toString())
+      t.is(typeof done, 'function')
+      return {
+        then (cb) {
+          cb()
+        }
+      }
     }
   }
   const res = {}
@@ -36,11 +42,14 @@ test('rawBody function', t => {
   rs.headers = { 'content-length': body.length }
   const request = new Request('params', rs, 'query', { 'content-length': body.length }, 'log')
   const reply = new Reply(res, context, {})
+  const done = () => {}
+
   internals.rawBody(
     request,
     reply,
     reply.context._parserOptions,
-    parser
+    parser,
+    done
   )
   rs.emit('data', body.toString())
   rs.emit('end')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Based on the effort (#1335) to increase Fastify test coverage to 100%, the test in this PR covers all `/lib/contentTypeParser.js` to 100%